### PR TITLE
Join game feature and added playground image to playground detail

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -6,7 +6,6 @@
   transition:  0.3s ease;
   font-family: $headers-font;
   border: 0px;
-  height: 3rem;
   align-items: center;
   &:hover {
     background: $second-orange;

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -5,6 +5,7 @@ class GamesController < ApplicationController
   def show
     @games = Game.find(params[:id])
     @user = User.where(game_id: @game)
+    @player = Player.new
   end
 
   def new_choose_playground

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -1,0 +1,3 @@
+class PlayersController < ApplicationController
+
+end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -1,3 +1,16 @@
 class PlayersController < ApplicationController
+  def create
+    @player_team = params[:player][:team].to_i
+    @game = Game.find(params[:player][:game].to_i)
 
+    @player = Player.new(confirmed_results: false, user: current_user)
+    @player.team = @player_team
+    @player.game = @game
+
+    if @player.save
+      redirect_to game_path(@game)
+    else
+      render 'games/show', status: :unprocessable_entity
+    end
+  end
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,4 +1,9 @@
 class Player < ApplicationRecord
   belongs_to :game
   belongs_to :user
+
+  enum team: {
+    red: 0,
+    blue: 1
+  }
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -22,6 +22,7 @@
           <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
         </div>
         <%= simple_form_for([@game, @player], url: players_path) do |f| %>
+          <%= f.hidden_field :game, value: params[:id] %>
           <%= f.hidden_field :team, value: 0 %>
           <%= f.submit 'Join', class: 'btn-small' %>
         <% end %>
@@ -35,6 +36,7 @@
           <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
         </div>
         <%= simple_form_for([@game, @player], url: players_path) do |f| %>
+          <%= f.hidden_field :game, value: params[:id] %>
           <%= f.hidden_field :team, value: 0 %>
           <%= f.submit 'Join', class: 'btn-small' %>
         <% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -22,6 +22,11 @@
           <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
         </div>
         <a href="#" class="btn-small">Join</a>
+
+        <%= simple_form_for([@game, @player]) do |f| %>
+          <%= f.submit %>
+        <% end %>
+
       </div>
       <h2>VS</h2>
       <div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,8 +1,7 @@
-<div class="playground-detail-image-game mb-3" style="background-image: url('https://img.src.ca/2015/07/12/1250x703/150712_hz82a_terrain-basket-chandler_sn1250.jpg')" alt=""></div>
+<div class="playground-detail-image-game mb-3" style="background-image: url('<%= cl_image_path @game.playground.photo.key if @game.playground.photo.attached? %>')" alt=""></div>
 <div class="container">
-  <div class="game-show"
-  data-controller="game-show">
-    <div class="d-flex justify-content-between align-items-center mt-3 mb-1">
+  <div class="game-show">
+    <div class="d-flex justify-content-between mt-3 mb-1">
       <h3 class="m-0" style="font-size: 20px;">Game on <%= @game.start_date.strftime("%m/%d/%Y") %></h3>
       <% if @game.game_mode == 'competitive' %>
         <p class="tag-competitive d-inline">Competitive</p>
@@ -10,16 +9,24 @@
         <p class="tag-casual d-inline">Casual</p>
       <% end %>
     </div>
-    <p>Starting at <%= @game.start_date.strftime("%I:%M%p") %> at <%= link_to @game.playground.name.downcase, playground_path(@game.playground.id) %></p>
-    <p class="d-flex justify-content-center mt-3 mb-3">Rank: <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small"></p>
+
+    <strong><%= @game.team_size %></strong>
+    <p>From <%= @game.start_date.strftime("%I:%M%p") %> to <%= (@game.start_date + 1.hour).strftime("%I:%M%p") %></p>
+    <p class="small"><%= link_to @game.playground.name, playground_path(@game.playground.id) %></p>
+
+
+    <p class="d-flex justify-content-center mt-3 mb-3">⭐</p>
 
     <div class="d-flex justify-content-between align-items-center teams">
       <div>
         <h4>Red team</h4>
         <div class="d-flex flex-wrap justify-content-between players">
-          <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
-          <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
-          <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
+          <% @game.players.where(team: 0).count.times do %>
+            <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
+          <% end %>
+          <% (@game.team_size.to_i - @game.players.where(team: 0).count).times do %>
+            <img src="https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460__340.png" class="avatar avatar-small player">
+          <% end %>
         </div>
         <%= simple_form_for([@game, @player], url: players_path) do |f| %>
           <%= f.hidden_field :game, value: params[:id] %>
@@ -29,21 +36,24 @@
       </div>
       <h2>VS</h2>
       <div>
-        <h4>Red team</h4>
+        <h4>Blue team</h4>
         <div class="d-flex flex-wrap justify-content-between players">
-          <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
-          <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
-          <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
+          <% @game.players.where(team: 1).count.times do %>
+            <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
+          <% end %>
+          <% (@game.team_size.to_i - @game.players.where(team: 1).count).times do %>
+            <img src="https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460__340.png" class="avatar avatar-small player">
+          <% end %>
         </div>
         <%= simple_form_for([@game, @player], url: players_path) do |f| %>
           <%= f.hidden_field :game, value: params[:id] %>
-          <%= f.hidden_field :team, value: 0 %>
+          <%= f.hidden_field :team, value: 1 %>
           <%= f.submit 'Join', class: 'btn-small' %>
         <% end %>
       </div>
     </div>
     <div class="mt-4 d-flex justify-content-center">
-      <%= link_to "Add Results", new_game_result_path(@game), class: "btn btn-primary" %>
+      <%= link_to "Add Results", new_game_result_path(@game), class: "btn btn-blue" %>
     </div>
   </div>
 </div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -21,12 +21,10 @@
           <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
           <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
         </div>
-        <a href="#" class="btn-small">Join</a>
-
-        <%= simple_form_for([@game, @player]) do |f| %>
-          <%= f.submit %>
+        <%= simple_form_for([@game, @player], url: players_path) do |f| %>
+          <%= f.hidden_field :team, value: 0 %>
+          <%= f.submit 'Join', class: 'btn-small' %>
         <% end %>
-
       </div>
       <h2>VS</h2>
       <div>
@@ -36,10 +34,14 @@
           <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
           <img src="https://kitt.lewagon.com/placeholder/users/ssaunier" class="avatar avatar-small player">
         </div>
-        <a href="#" class="btn-small">Join</a>
+        <%= simple_form_for([@game, @player], url: players_path) do |f| %>
+          <%= f.hidden_field :team, value: 0 %>
+          <%= f.submit 'Join', class: 'btn-small' %>
+        <% end %>
       </div>
     </div>
-    <br>
-    <%= link_to "Add Results", new_game_result_path(@game), class: "btn btn-primary" %>
+    <div class="mt-4 d-flex justify-content-center">
+      <%= link_to "Add Results", new_game_result_path(@game), class: "btn btn-primary" %>
+    </div>
   </div>
 </div>

--- a/app/views/playgrounds/show.html.erb
+++ b/app/views/playgrounds/show.html.erb
@@ -1,4 +1,4 @@
-<div class="playground-detail-image mb-3" style="background-image: url('https://img.src.ca/2015/07/12/1250x703/150712_hz82a_terrain-basket-chandler_sn1250.jpg')" alt=""></div>
+<div class="playground-detail-image mb-3" style="background-image: url('<%= cl_image_path @playground.photo.key if @playground.photo.attached? %>')" alt=""></div>
 <div class="container">
   <div class="playground-details d-flex">
     <div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
     resources :results, only: %i[new create]
   end
 
+  resources :players, only: :create
+  patch '/games/:game_id/players', to: 'players#update'
+
   resources :results, only: %i[show]
 
   get '/playgrounds_nearby', to: 'playgrounds#playgrounds_nearby'

--- a/test/controllers/players_controller_test.rb
+++ b/test/controllers/players_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PlayersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Changes:
- It is now possible to join a game and a team on a game showpage.
- The players of each team are visually updated each time a new player joins.
- Added the actual image of the playground in the playground and game showpages.

How to test:
GOTO '/games/:game_id' and try to join a team

Screens:
<img width="215" alt="image" src="https://user-images.githubusercontent.com/49365826/186951807-fccd6e87-b228-4432-996c-cb45ca7d9dd3.png">

Please review @MikaelJG @julienLeMee @jchau905 