### PR TITLE
Add map and Google Maps API

### DIFF
--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -6,3 +6,8 @@
   display: flex;
   top: 0;
 }
+
+#map {
+  height: 400px;
+  width: 100%;
+}

--- a/app/controllers/playgrounds_controller.rb
+++ b/app/controllers/playgrounds_controller.rb
@@ -10,5 +10,6 @@ class PlaygroundsController < ApplicationController
   end
 
   def playgrounds_nearby
+    @playgrounds = Playground.all
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,5 +10,8 @@ application.register("game-form", GameFormController)
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import MapController from "./map_controller"
+application.register("map", MapController)
+
 import TomSelectController from "./tom_select_controller"
 application.register("tom-select", TomSelectController)

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -2,7 +2,12 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="map"
 export default class extends Controller {
+  static values = {
+    playgrounds: Array
+  }
+
   connect() {
+    console.log(this.playgroundsValue);
     window.initMap = this.#initMap();
   }
 

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="map"
+export default class extends Controller {
+  connect() {
+    window.initMap = this.#initMap();
+  }
+
+  // Initialize and add the map
+  #initMap() {
+    // The location of Uluru
+    const uluru = { lat: -25.344, lng: 131.031 };
+    // The map, centered at Uluru
+    const map = new google.maps.Map(this.element, {
+      zoom: 4,
+      center: uluru,
+    });
+    // The marker, positioned at Uluru
+    const marker = new google.maps.Marker({
+      position: uluru,
+      map: map,
+    });
+  }
+}

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -9,15 +9,15 @@ export default class extends Controller {
   // Initialize and add the map
   #initMap() {
     // The location of Uluru
-    const uluru = { lat: -25.344, lng: 131.031 };
-    // The map, centered at Uluru
+    const montreal = { lat: 45.5050700377646, lng: -73.57248431277986 };
+    // The map, centered at Montreal
     const map = new google.maps.Map(this.element, {
-      zoom: 8,
-      center: uluru,
+      zoom: 10,
+      center: montreal,
     });
     // The marker, positioned at Uluru
     const marker = new google.maps.Marker({
-      position: uluru,
+      position: montreal,
       map: map,
     });
   }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
     const uluru = { lat: -25.344, lng: 131.031 };
     // The map, centered at Uluru
     const map = new google.maps.Map(this.element, {
-      zoom: 4,
+      zoom: 8,
       center: uluru,
     });
     // The marker, positioned at Uluru

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <title>MeetBall</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= favicon_link_tag%>

--- a/app/views/playgrounds/playgrounds_nearby.html.erb
+++ b/app/views/playgrounds/playgrounds_nearby.html.erb
@@ -1,8 +1,14 @@
-
-<div class="map">
+<%# <div class="map">
   <img src="https://res.cloudinary.com/dvbzytnxf/image/upload/v1661464611/google-map-Christian-salette-01-e1505739837933_hy7qk5.jpg" alt="map">
 </div>
 
 <div class="container mt-4">
   <%= render "shared/searchform" %>
-</div>
+<%# </div> %>
+
+
+<div id="map" data-controller="map"></div>
+
+
+<!-- Google Maps API -->
+<%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=AIzaSyAJmqLvSNaQn_bhVPmN_gR82I8s5TyN8r0&callback=initMap" %>

--- a/app/views/playgrounds/playgrounds_nearby.html.erb
+++ b/app/views/playgrounds/playgrounds_nearby.html.erb
@@ -7,7 +7,7 @@
 <%# </div> %>
 
 
-<div id="map" data-controller="map"></div>
+<div id="map" data-controller="map" data-map-value="<%= @playgrounds %>"></div>
 
 
 <!-- Google Maps API -->

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -118,16 +118,20 @@ end
 def build_playground(json)
   json["results"].each do |result|
     if result["photos"]
-      key = "AIzaSyAJmqLvSNaQn_bhVPmN_gR82I8s5TyN8r0"
-
-      photo_reference = result["photos"][0]["photo_reference"]
-      photo_url = "https://maps.googleapis.com/maps/api/place/photo?maxwidth=1000&photo_reference=#{photo_reference}&key=#{key}"
-      p photo_url
-
       playground = Playground.create(
         name: result["name"],
         address: result["formatted_address"]
       )
+
+      key = "AIzaSyAJmqLvSNaQn_bhVPmN_gR82I8s5TyN8r0"
+
+      photo_reference = result["photos"][0]["photo_reference"]
+      photo_url = "https://maps.googleapis.com/maps/api/place/photo?maxwidth=1000&photo_reference=#{photo_reference}&key=#{key}"
+
+      playground_image = URI.open(photo_url)
+      playground.photo.attach(io: playground_image, filename: "#{playground['name']}.png", content_type: "image/png")
+      playground.save!
+      puts "Image given to playground"
 
       puts "Playground #{playground.name} successfully created"
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -108,22 +108,41 @@ images_url = [
 
 # response = https.request(playgrounds_api_request)
 
+google_key = "AIzaSyAJmqLvSNaQn_bhVPmN_gR82I8s5TyN8r0"
 
-playgrounds_api_url = 'https://maps.googleapis.com/maps/api/place/textsearch/json?query=terrain%20de%20basketball%20montreal&key=AIzaSyAJmqLvSNaQn_bhVPmN_gR82I8s5TyN8r0'
-playgrounds_api_serialized = URI.open(playgrounds_api_url).read
-playgrounds_api = JSON.parse(playgrounds_api_serialized)
-
-playgrounds_api["results"].each do |result|
-  playground = Playground.create(
-    name: result["name"],
-    address: result["formatted_address"]
-  )
-
-  puts playground
+def read_and_parse_url(url)
+  playgrounds_api_serialized = URI.open(url).read
+  JSON.parse(playgrounds_api_serialized)
 end
 
+def build_playground(json)
+  json["results"].each do |result|
+    if result["photos"]
+      key = "AIzaSyAJmqLvSNaQn_bhVPmN_gR82I8s5TyN8r0"
 
+      photo_reference = result["photos"][0]["photo_reference"]
+      photo_url = "https://maps.googleapis.com/maps/api/place/photo?maxwidth=1000&photo_reference=#{photo_reference}&key=#{key}"
+      p photo_url
 
+      playground = Playground.create(
+        name: result["name"],
+        address: result["formatted_address"]
+      )
+
+      puts "Playground #{playground.name} successfully created"
+    end
+  end
+end
+
+playgrounds_api_url = "https://maps.googleapis.com/maps/api/place/textsearch/json?query=terrain%20de%20basketball%20montreal&key=#{google_key}"
+playgrounds_api = read_and_parse_url(playgrounds_api_url)
+
+build_playground(playgrounds_api)
+
+next_url = "https://maps.googleapis.com/maps/api/place/textsearch/json?pagetoken=AeJbb3ecvytDQ8MDiX4xew_UmIgEGO0Qc7BSb6xCXvGIeHAOAbRbQuIhhwLrkJMspA8DWOWoWUekEUjwMBQwx343s6Tx7D88vGKjSZ-4bnRxNFpESQYgETw7T5W3ISTlJg6xKwJsrRrsHi2UJ6YwX5I6t_IXS-U8Pgu7KxrHZzjitVToSFQdsS_ss9q9sJkPLpeM_c9cVqTSdfO_3l4vBcPTwQvZjLNrCcgeR_S-0FWUlDAxpAFiL6u4J2YHe6i5uv0cBh5HLWu0TRT4xdO8tN4ktvGHJWbnGuD-1z4W7KcUFdCtyUPxPoGyVEQPToimYlGx7LJZdH62-MyW1GZiR78kkVgao11wnOaDScBk37I_H_Nx9YyhaDflbCd-xxooMnzMeEtQw6THNTMhpFraZY3gKKaOWvSQMGlyWYWv7g&query=terrain%20de%20basketball%20montreal&key=#{google_key}"
+playgrounds_api = read_and_parse_url(next_url)
+
+build_playground(playgrounds_api)
 
 
 # 10.times do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,55 +33,54 @@ images_url = [
 
 puts "Creating users..."
 
-3.times do
-  user = User.create(
-    username: Faker::Internet.username(specifier: 10),
-    email: Faker::Internet.email,
-    password: Faker::Internet.password
-  )
+# 3.times do
+#   user = User.create(
+#     username: Faker::Internet.username(specifier: 10),
+#     email: Faker::Internet.email,
+#     password: Faker::Internet.password
+#   )
 
-  game = Game.new(
-    start_date: Faker::Time.between(from: DateTime.now - 2, to: DateTime.now - 1, format: :default),
-    end_date: Faker::Time.between(from: DateTime.now - 1, to: DateTime.now, format: :default),
-    game_mode: rand(0..1),
-    team_size: rand(0..2)
-  )
+#   game = Game.new(
+#     start_date: Faker::Time.between(from: DateTime.now - 2, to: DateTime.now - 1, format: :default),
+#     end_date: Faker::Time.between(from: DateTime.now - 1, to: DateTime.now, format: :default),
+#     game_mode: rand(0..1),
+#     team_size: rand(0..2)
+#   )
 
-  enum = game.team_size.to_i
-  number_of_players = enum * 2
+#   enum = game.team_size.to_i
+#   number_of_players = enum * 2
 
-  puts "Created game. Team size enum is : #{enum}. Number of players needed is #{number_of_players}."
+#   puts "Created game. Team size enum is : #{enum}. Number of players needed is #{number_of_players}."
 
-  number_of_players.times do
-    player = Player.new(
-      confirmed_results: [true, false].sample,
-      team: rand(0..1)
-    )
+#   number_of_players.times do
+#     player = Player.new(
+#       confirmed_results: [true, false].sample,
+#       team: rand(0..1)
+#     )
 
-    player.user = user
-    player.game = game
-    player.save!
+#     player.user = user
+#     player.game = game
+#     player.save!
 
-  end
+#   end
 
-  start_date = game.start_date
+#   start_date = game.start_date
 
-  game.end_date = start_date + 1.hour
+#   game.end_date = start_date + 1.hour
 
-  game.user = main_user
+#   game.user = main_user
 
-  playground = Playground.create(
-    name: "The #{Faker::Sports::Basketball.team} Arena",
-    address: Faker::Address.street_address,
-    description: Faker::JapaneseMedia::OnePiece.quote
-  )
+#   playground = Playground.create(
+#     name: "The #{Faker::Sports::Basketball.team} Arena",
+#     address: Faker::Address.street_address,
+#     description: Faker::JapaneseMedia::OnePiece.quote
+#   )
 
-  playgrounds_without_images << playground
+#   playgrounds_without_images << playground
 
-  game.playground = playground
-  game.save!
-
-end
+#   game.playground = playground
+#   game.save!
+# end
 
 # playgrounds_api_url = 'https://storage.googleapis.com/dx-montreal/resources/2dac229f-6089-4cb7-ab0b-eadc6a147d5d/terrain_sport_ext.json'
 # playgrounds_api_serialized = URI.open(playgrounds_api_url).read
@@ -94,8 +93,6 @@ end
 #     )
 #   end
 # end
-
-google_key = "AIzaSyAJmqLvSNaQn_bhVPmN_gR82I8s5TyN8r0"
 
 def read_and_parse_url(url)
   playgrounds_api_serialized = URI.open(url).read
@@ -111,10 +108,8 @@ def build_playground(json)
       )
       puts "Playground #{playground.name} successfully created"
 
-      key = "AIzaSyAJmqLvSNaQn_bhVPmN_gR82I8s5TyN8r0"
-
       photo_reference = result["photos"][0]["photo_reference"]
-      photo_url = "https://maps.googleapis.com/maps/api/place/photo?maxwidth=1000&photo_reference=#{photo_reference}&key=#{key}"
+      photo_url = "https://maps.googleapis.com/maps/api/place/photo?maxwidth=1000&photo_reference=#{photo_reference}&key=#{ENV['GMAPS_API']}"
 
       playground_image = URI.open(photo_url)
       playground.photo.attach(io: playground_image, filename: "#{playground['name']}.png", content_type: "image/png")
@@ -130,14 +125,20 @@ def create_playgrounds_from_url(url)
   return json["next_page_token"]
 end
 
-playgrounds_api_url = "https://maps.googleapis.com/maps/api/place/textsearch/json?query=terrain%20de%20basketball%20montreal&key=#{google_key}"
+playgrounds_api_url = "https://maps.googleapis.com/maps/api/place/textsearch/json?query=terrain%20de%20basketball%20montreal&key=#{ENV['GMAPS_API']}"
 next_token = create_playgrounds_from_url(playgrounds_api_url)
 
-playgrounds_api_url2 = "https://maps.googleapis.com/maps/api/place/textsearch/json?pagetoken=#{next_token}&query=terrain%20de%20basketball%20montreal&key=#{google_key}"
+playgrounds_api_url2 = "https://maps.googleapis.com/maps/api/place/textsearch/json?pagetoken=#{next_token}&query=terrain%20de%20basketball%20montreal&key=#{ENV['GMAPS_API']}"
 next_token = create_playgrounds_from_url(playgrounds_api_url2)
 
-playgrounds_api_url3 = "https://maps.googleapis.com/maps/api/place/textsearch/json?pagetoken=#{next_token}&query=terrain%30de%20basketball%20montreal&key=#{google_key}"
+playgrounds_api_url3 = "https://maps.googleapis.com/maps/api/place/textsearch/json?pagetoken=#{next_token}&query=terrain%30de%20basketball%20montreal&key=#{ENV['GMAPS_API']}"
 next_token = create_playgrounds_from_url(playgrounds_api_url3)
+
+playgrounds_api_url4 = "https://maps.googleapis.com/maps/api/place/textsearch/json?pagetoken=#{next_token}&query=terrain%30de%20basketball%20montreal&key=#{ENV['GMAPS_API']}"
+next_token = create_playgrounds_from_url(playgrounds_api_url4)
+
+playgrounds_api_url5 = "https://maps.googleapis.com/maps/api/place/textsearch/json?pagetoken=#{next_token}&query=terrain%30de%20basketball%20montreal&key=#{ENV['GMAPS_API']}"
+next_token = create_playgrounds_from_url(playgrounds_api_url5)
 
 
 10.times do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,8 @@ images_url = [
   "https://res.cloudinary.com/meetball/image/upload/v1661453646/Chicago_Bulls.webp",
   "https://res.cloudinary.com/meetball/image/upload/v1661453646/Boston_Celtics.jpg",
   "https://res.cloudinary.com/meetball/image/upload/v1661453646/LA_Clippers.jpg",
-  "https://res.cloudinary.com/meetball/image/upload/v1661453646/Denver_Nuggets.webp"]
+  "https://res.cloudinary.com/meetball/image/upload/v1661453646/Denver_Nuggets.webp"
+]
 
 # 3.times do
 #   user = User.create(
@@ -81,6 +82,21 @@ images_url = [
 # end
 
 # puts "Creating users..."
+
+
+playgrounds_api_url = 'https://storage.googleapis.com/dx-montreal/resources/2dac229f-6089-4cb7-ab0b-eadc6a147d5d/terrain_sport_ext.json'
+playgrounds_api_serialized = URI.open(playgrounds_api_url).read
+playgrounds_api = JSON.parse(playgrounds_api_serialized)
+
+playgrounds_api["features"].each do |record|
+  if record["properties"]["NOM"].include?("Basketball")
+    p record
+  end
+end
+
+
+
+
 
 10.times do
   user = User.create(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,56 +31,7 @@ images_url = [
   "https://res.cloudinary.com/meetball/image/upload/v1661453646/Denver_Nuggets.webp"
 ]
 
-puts "Creating users..."
-
-# 3.times do
-#   user = User.create(
-#     username: Faker::Internet.username(specifier: 10),
-#     email: Faker::Internet.email,
-#     password: Faker::Internet.password
-#   )
-
-#   game = Game.new(
-#     start_date: Faker::Time.between(from: DateTime.now - 2, to: DateTime.now - 1, format: :default),
-#     end_date: Faker::Time.between(from: DateTime.now - 1, to: DateTime.now, format: :default),
-#     game_mode: rand(0..1),
-#     team_size: rand(0..2)
-#   )
-
-#   enum = game.team_size.to_i
-#   number_of_players = enum * 2
-
-#   puts "Created game. Team size enum is : #{enum}. Number of players needed is #{number_of_players}."
-
-#   number_of_players.times do
-#     player = Player.new(
-#       confirmed_results: [true, false].sample,
-#       team: rand(0..1)
-#     )
-
-#     player.user = user
-#     player.game = game
-#     player.save!
-
-#   end
-
-#   start_date = game.start_date
-
-#   game.end_date = start_date + 1.hour
-
-#   game.user = main_user
-
-#   playground = Playground.create(
-#     name: "The #{Faker::Sports::Basketball.team} Arena",
-#     address: Faker::Address.street_address,
-#     description: Faker::JapaneseMedia::OnePiece.quote
-#   )
-
-#   playgrounds_without_images << playground
-
-#   game.playground = playground
-#   game.save!
-# end
+puts "Creating playgrounds..."
 
 # playgrounds_api_url = 'https://storage.googleapis.com/dx-montreal/resources/2dac229f-6089-4cb7-ab0b-eadc6a147d5d/terrain_sport_ext.json'
 # playgrounds_api_serialized = URI.open(playgrounds_api_url).read

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,7 @@
 require 'faker'
 require 'open-uri'
+require "uri"
+require "net/http"
 
 puts "Deleting all the models..."
 Result.destroy_all
@@ -84,159 +86,185 @@ images_url = [
 # puts "Creating users..."
 
 
-playgrounds_api_url = 'https://storage.googleapis.com/dx-montreal/resources/2dac229f-6089-4cb7-ab0b-eadc6a147d5d/terrain_sport_ext.json'
+# playgrounds_api_url = 'https://storage.googleapis.com/dx-montreal/resources/2dac229f-6089-4cb7-ab0b-eadc6a147d5d/terrain_sport_ext.json'
+# playgrounds_api_serialized = URI.open(playgrounds_api_url).read
+# playgrounds_api = JSON.parse(playgrounds_api_serialized)
+
+# playgrounds_api["features"].each do |record|
+#   if record["properties"]["NOM"].include?("Basketball")
+#     Playground.create(
+#       name:
+#     )
+#   end
+# end
+
+
+# playgrounds_api_url = URI("https://maps.googleapis.com/maps/api/place/textsearch/json?query=terrain%20de%20basketball%20montreal&key=AIzaSyAJmqLvSNaQn_bhVPmN_gR82I8s5TyN8r0")
+
+# https = Net::HTTP.new(playgrounds_api_url.host, playgrounds_api_url.port)
+# https.use_ssl = true
+
+# playgrounds_api_request = Net::HTTP::Get.new(playgrounds_api_url)
+
+# response = https.request(playgrounds_api_request)
+
+
+playgrounds_api_url = 'https://maps.googleapis.com/maps/api/place/textsearch/json?query=terrain%20de%20basketball%20montreal&key=AIzaSyAJmqLvSNaQn_bhVPmN_gR82I8s5TyN8r0'
 playgrounds_api_serialized = URI.open(playgrounds_api_url).read
 playgrounds_api = JSON.parse(playgrounds_api_serialized)
 
-playgrounds_api["features"].each do |record|
-  if record["properties"]["NOM"].include?("Basketball")
-    p record
-  end
-end
-
-
-
-
-
-10.times do
-  user = User.create(
-    username: Faker::Internet.username(specifier: 10),
-    email: Faker::Internet.email,
-    password: Faker::Internet.password
-  )
-
-  puts "Successfully created #{user.username} with #{user.email}"
-
-  puts '--------------------------------'
-
-  puts "Creating playgrounds..."
-
+playgrounds_api["results"].each do |result|
   playground = Playground.create(
-    name: "The #{Faker::Sports::Basketball.team} Arena",
-    address: Faker::Address.street_address,
-    description: Faker::JapaneseMedia::OnePiece.quote
+    name: result["name"],
+    address: result["formatted_address"]
   )
 
-  playgrounds_without_images << playground
-  puts '--------------------------------'
-
-  puts "Successfully created #{playground.name} at #{playground.address} with #{playground.description}"
-
-  puts '--------------------------------'
-
-  games = []
-
-  3.times do
-    game = Game.new(
-      start_date: Faker::Time.between(from: DateTime.now - 2, to: DateTime.now - 1, format: :default),
-      end_date: Faker::Time.between(from: DateTime.now - 1, to: DateTime.now, format: :default),
-      game_mode: rand(0..1),
-      team_size: rand(0..2)
-    )
-
-    start_date = game.start_date
-
-    game.end_date = start_date + 1.hour
-
-    game.user = user
-    game.playground = playground
-    game.save!
-
-    games << game
-  end
-
-  games.each do |game|
-    puts "Successfully created a #{game.game_mode == 0 ? 'Competitive' : 'Casual'} game starting at #{game.start_date} to #{game.end_date}"
-  end
-
-  puts '--------------------------------'
-
-  players = []
-  players_who_confirmed = []
-
-  games.each do |game|
-
-    enum = game.team_size.to_i
-    number_of_players = enum * 2
-
-    puts "inside game. Team size enum is : #{enum}. Entering number_of_players.times with #{number_of_players} number of players."
-
-    (enum - 1).times do
-      player = Player.new(
-        confirmed_results: [true, false].sample,
-        team: 1
-      )
-
-      player.user = user
-      player.game = game
-      player.save!
-
-      players << player
-
-      puts "player saved!"
-
-    end
-
-    (enum - rand(0..1)).times do
-      player = Player.new(
-        confirmed_results: [true, false].sample,
-        team: 0
-      )
-
-      player.user = user
-      player.game = game
-      player.save!
-
-      players << player
-
-      puts "player saved!"
-
-    end
-
-  end
-
-  puts "games.each do. done."
-
-  players.each do |player|
-    puts "Successfully created player in team: #{player.team == 0 ? 'Red' : 'Blue'}. The player has #{player.confirmed_results ? 'Confirmed' : 'Not confirmed'} game results."
-    puts "Attributed to game starting #{player.game.start_date}. Same player is user #{player.user.username}."
-
-    puts '--------------------------------'
-
-    if player.confirmed_results?
-      players_who_confirmed << player
-    end
-  end
-
-  if (players.length / 2).to_f > players_who_confirmed.length
-    status = 0
-  else
-    status = 1
-  end
-
-  result = Result.new(
-    red_score: [20..50].sample,
-    blue_score: [20..50].sample,
-    status: status
-  )
-
-  result.game = games.sample
-  result.save!
-
-  puts "Successfully created results for game: #{result.game}."
-  puts "#{players_who_confirmed.length} players confirmed the game results. Results are #{result.status == 0 ? "Confirmed" : "Not confirmed"}."
+  puts playground
 end
 
-playgrounds_without_images.each do |playground|
-  puts "------------------------------------"
-  playground_image = URI.open(images_url.sample)
-  playground.photo.attach(io: playground_image, filename: "image.png", content_type: "image/png")
-  playground.save!
-  puts "image given to playground"
-end
 
-puts '--------------------------------'
 
-puts "Seed completed with success"
 
-puts '--------------------------------'
+
+# 10.times do
+#   user = User.create(
+#     username: Faker::Internet.username(specifier: 10),
+#     email: Faker::Internet.email,
+#     password: Faker::Internet.password
+#   )
+
+#   puts "Successfully created #{user.username} with #{user.email}"
+
+#   puts '--------------------------------'
+
+#   puts "Creating playgrounds..."
+
+#   playground = Playground.create(
+#     name: "The #{Faker::Sports::Basketball.team} Arena",
+#     address: Faker::Address.street_address,
+#     description: Faker::JapaneseMedia::OnePiece.quote
+#   )
+
+#   playgrounds_without_images << playground
+#   puts '--------------------------------'
+
+#   puts "Successfully created #{playground.name} at #{playground.address} with #{playground.description}"
+
+#   puts '--------------------------------'
+
+#   games = []
+
+#   3.times do
+#     game = Game.new(
+#       start_date: Faker::Time.between(from: DateTime.now - 2, to: DateTime.now - 1, format: :default),
+#       end_date: Faker::Time.between(from: DateTime.now - 1, to: DateTime.now, format: :default),
+#       game_mode: rand(0..1),
+#       team_size: rand(0..2)
+#     )
+
+#     start_date = game.start_date
+
+#     game.end_date = start_date + 1.hour
+
+#     game.user = user
+#     game.playground = playground
+#     game.save!
+
+#     games << game
+#   end
+
+#   games.each do |game|
+#     puts "Successfully created a #{game.game_mode == 0 ? 'Competitive' : 'Casual'} game starting at #{game.start_date} to #{game.end_date}"
+#   end
+
+#   puts '--------------------------------'
+
+#   players = []
+#   players_who_confirmed = []
+
+#   games.each do |game|
+
+#     enum = game.team_size.to_i
+#     number_of_players = enum * 2
+
+#     puts "inside game. Team size enum is : #{enum}. Entering number_of_players.times with #{number_of_players} number of players."
+
+#     (enum - 1).times do
+#       player = Player.new(
+#         confirmed_results: [true, false].sample,
+#         team: 1
+#       )
+
+#       player.user = user
+#       player.game = game
+#       player.save!
+
+#       players << player
+
+#       puts "player saved!"
+
+#     end
+
+#     (enum - rand(0..1)).times do
+#       player = Player.new(
+#         confirmed_results: [true, false].sample,
+#         team: 0
+#       )
+
+#       player.user = user
+#       player.game = game
+#       player.save!
+
+#       players << player
+
+#       puts "player saved!"
+
+#     end
+
+#   end
+
+#   puts "games.each do. done."
+
+#   players.each do |player|
+#     puts "Successfully created player in team: #{player.team == 0 ? 'Red' : 'Blue'}. The player has #{player.confirmed_results ? 'Confirmed' : 'Not confirmed'} game results."
+#     puts "Attributed to game starting #{player.game.start_date}. Same player is user #{player.user.username}."
+
+#     puts '--------------------------------'
+
+#     if player.confirmed_results?
+#       players_who_confirmed << player
+#     end
+#   end
+
+#   if (players.length / 2).to_f > players_who_confirmed.length
+#     status = 0
+#   else
+#     status = 1
+#   end
+
+#   result = Result.new(
+#     red_score: [20..50].sample,
+#     blue_score: [20..50].sample,
+#     status: status
+#   )
+
+#   result.game = games.sample
+#   result.save!
+
+#   puts "Successfully created results for game: #{result.game}."
+#   puts "#{players_who_confirmed.length} players confirmed the game results. Results are #{result.status == 0 ? "Confirmed" : "Not confirmed"}."
+# end
+
+# playgrounds_without_images.each do |playground|
+#   puts "------------------------------------"
+#   playground_image = URI.open(images_url.sample)
+#   playground.photo.attach(io: playground_image, filename: "image.png", content_type: "image/png")
+#   playground.save!
+#   puts "image given to playground"
+# end
+
+# puts '--------------------------------'
+
+# puts "Seed completed with success"
+
+# puts '--------------------------------'


### PR DESCRIPTION
Changes:
- Added Gmaps Javascript API to see the nearby playgrounds
- Added Gmaps Places API to generated real Montreal playgrounds with images when seeding

How to test:
ADD the API key sent on Slack as GMAPS_API in your .env file
GOTO '/playgrounds_nearby'

Screens:
<img width="237" alt="image" src="https://user-images.githubusercontent.com/49365826/187218367-05c13e99-902d-41bd-b308-ed4a791b34d6.png">
<img width="210" alt="image" src="https://user-images.githubusercontent.com/49365826/187218516-20e48553-4523-4447-922f-6dcdcb9f37cf.png">

Please review @jchau905 @julienLeMee @MikaelJG 
