### PR TITLE
Add badges images to results

### DIFF
--- a/app/assets/stylesheets/components/_result.scss
+++ b/app/assets/stylesheets/components/_result.scss
@@ -32,15 +32,27 @@
   position: relative;
   top: 50px;
   display: flex;
-  left: 45px;
   background-color: white;
   border-radius: $border-radius;
   box-shadow: $box-shadow;
   flex-wrap: wrap;
 }
+.badges-left {
+  width: 265px;
+  left: 95px;
+}
+.badges-right {
+  width: 265px;
+  right: 80px;
+}
 .badges-container {
   position: absolute;
   display: none;
+}
+.badges-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 10px;
 }
 body > div.container > div > div.results.d-flex.justify-content-between.pt-4.pb-4 > div.red-team.d-flex.flex-column.align-items-center > ul > li:nth-child(1) > div {
   display: block;

--- a/app/assets/stylesheets/components/_result.scss
+++ b/app/assets/stylesheets/components/_result.scss
@@ -5,7 +5,6 @@
 .results ul {
   list-style: none;
   padding: 0;
-  margin: 0;
 }
 .red-team, .blue-team {
   width: 50%;
@@ -18,10 +17,6 @@
   height: 38px;
   margin-right: 0px;
   transition: .3s;
-
-  &:hover {
-
-  }
 }
 .results-list-item {
   width: 82px;
@@ -36,6 +31,7 @@
   border-radius: $border-radius;
   box-shadow: $box-shadow;
   flex-wrap: wrap;
+  margin-bottom: 150px;
 }
 .badges-left {
   width: 265px;
@@ -53,7 +49,4 @@
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 10px;
-}
-body > div.container > div > div.results.d-flex.justify-content-between.pt-4.pb-4 > div.red-team.d-flex.flex-column.align-items-center > ul > li:nth-child(1) > div {
-  display: block;
 }

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -17,7 +17,8 @@ class PlayersController < ApplicationController
   def update
     @game = Game.find(params[:game_id])
     @player = @game.players.where(user_id: current_user.id)
-    @player.update(confirmed_results: true)
+    @confirmed = params[:player][:confirmed_results]
+    @player.update(confirmed_results: @confirmed)
     majority = @game.team_size.to_i + 1
     players_confirmed_score = @game.players.count { |player| player.confirmed_results }
     if players_confirmed_score >= majority

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -16,8 +16,14 @@ application.register("hello", HelloController)
 import MapController from "./map_controller"
 application.register("map", MapController)
 
+import ResultsBlueController from "./results_blue_controller"
+application.register("results-blue", ResultsBlueController)
+
+import ResultsRedController from "./results_red_controller"
+application.register("results-red", ResultsRedController)
+
 import TomSelectController from "./tom_select_controller"
 application.register("tom-select", TomSelectController)
 
-import UpcomingGames from "./upcoming_games_controller"
-application.register("upcoming_games", UpcomingGames)
+import UpcomingGamesController from "./upcoming_games_controller"
+application.register("upcoming-games", UpcomingGamesController)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,6 +19,9 @@ application.register("map", MapController)
 import ResultsBlueController from "./results_blue_controller"
 application.register("results-blue", ResultsBlueController)
 
+import ResultsController from "./results_controller"
+application.register("results", ResultsController)
+
 import ResultsRedController from "./results_red_controller"
 application.register("results-red", ResultsRedController)
 

--- a/app/javascript/controllers/results_blue_controller.js
+++ b/app/javascript/controllers/results_blue_controller.js
@@ -5,9 +5,15 @@ export default class extends Controller {
   static targets = ["badges"];
 
   connect() {
+    window.addEventListener("click", (event) => {
+      if (event.target.contains(this.badgesTarget) && this.badgesTarget.style.display === "block") {
+        this.badgesTarget.style.display = "none";
+      }
+    });
   }
 
   toggleBadges() {
+    this.badgesTarget.style.display = "none";
     this.badgesTarget.style.display = "block";
   }
 }

--- a/app/javascript/controllers/results_blue_controller.js
+++ b/app/javascript/controllers/results_blue_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="results-blue"
+export default class extends Controller {
+  static targets = ["badges"];
+
+  connect() {
+  }
+
+  toggleBadges() {
+    this.badgesTarget.style.display = "block";
+  }
+}

--- a/app/javascript/controllers/results_red_controller.js
+++ b/app/javascript/controllers/results_red_controller.js
@@ -5,9 +5,15 @@ export default class extends Controller {
   static targets = ["badges"];
 
   connect() {
+    window.addEventListener("click", (event) => {
+      if (event.target.contains(this.badgesTarget) && this.badgesTarget.style.display === "block") {
+        this.badgesTarget.style.display = "none";
+      }
+    });
   }
 
   toggleBadges() {
+    this.badgesTarget.style.display = "none";
     this.badgesTarget.style.display = "block";
   }
 }

--- a/app/javascript/controllers/results_red_controller.js
+++ b/app/javascript/controllers/results_red_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="results-red"
+export default class extends Controller {
+  static targets = ["badges"];
+
+  connect() {
+  }
+
+  toggleBadges() {
+    this.badgesTarget.style.display = "block";
+  }
+}

--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -33,16 +33,20 @@
               <li class="results-list-item">
                 <%= cl_image_tag player.user.photo.key, class: "avatar avatar-results player" %>
                 <div class="badges-container">
-                  <ul class="badges p-3">
+                  <ul class="badges badges-left p-3">
+                  <div class="badges-grid">
                     <% Badge.all.each do |badge| %>
+                      <li>
                         <%= form_with(url: user_badge_path, method: :post) do |f| %>
                           <%= f.hidden_field :user_id, value: player.user.id %>
                           <%= f.hidden_field :badge_id, value: badge.id %>
                           <%= f.hidden_field :result_id, value: @result.id %>
-                          <%= f.submit badge.name.capitalize, type: :image, src: "http://res.cloudinary.com/meetball/image/upload/v1/development/#{badge.photo.key}", class: "avatar avatar-results player" %>
+                          <%= f.submit badge.name.capitalize, type: :image, src: "http://res.cloudinary.com/meetball/image/upload/v1/development/#{badge.photo.key}", class: "avatar avatar-results player mb-0" %>
                         <% end %>
+                        <p class="small"><%= badge.name.capitalize %></p>
                       </li>
                     <% end %>
+                  </div>
                   </ul>
                 </div>
               </li>
@@ -63,9 +67,28 @@
         <ul class="results-list d-flex flex-wrap">
           <% @players.where(team: 1).each do |player| %>
             <% if player.user.photo.attached? %>
-              <li class="results-list-item"><%= cl_image_tag player.user.photo.key, class: "avatar avatar-results player" %></li>
+              <li class="results-list-item">
+                <%= cl_image_tag player.user.photo.key, class: "avatar avatar-results player" %>
+                <div class="badges-container">
+                  <ul class="badges badges-right p-3">
+                  <div class="badges-grid">
+                    <% Badge.all.each do |badge| %>
+                      <li>
+                        <%= form_with(url: user_badge_path, method: :post) do |f| %>
+                          <%= f.hidden_field :user_id, value: player.user.id %>
+                          <%= f.hidden_field :badge_id, value: badge.id %>
+                          <%= f.hidden_field :result_id, value: @result.id %>
+                          <%= f.submit badge.name.capitalize, type: :image, src: "http://res.cloudinary.com/meetball/image/upload/v1/development/#{badge.photo.key}", class: "avatar avatar-results player mb-0" %>
+                        <% end %>
+                        <p class="small"><%= badge.name.capitalize %></p>
+                      </li>
+                    <% end %>
+                  </div>
+                  </ul>
+                </div>
+              </li>
             <% else %>
-              <li class="results-list-item"><img src="https://cdn-icons-png.flaticon.com/512/5357/5357861.png" class="avatar avatar-results player"></li>
+              <li class="results-list-item"><img src="https://cdn-icons-png.flaticon.com/512/5357/5357686.png" class="avatar avatar-results player"></li>
             <% end %>
           <% end %>
         </ul>

--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <h1 class="mt-3 mb-1">Results</h1>
-    <div class="d-flex justify-content-between align-items-center">
+    <div class="d-flex justify-content-between align-items-center mb-3">
       <h3 class="m-0" style="font-size: 20px;">Game on <%= @game.start_date.strftime("%m/%d/%Y") %></h3>
       <% if @game.game_mode == 'competitive' %>
         <p class="tag-competitive d-inline">Competitive</p>
@@ -11,6 +11,9 @@
     <p>At <%= link_to @game.playground.name.downcase, playground_path(@game.playground.id) %></p>
     <div class="d-flex flex-column align-items-center mt-4 mb-4">
       <%  if @player.user.rank && @game.game_mode == 'competitive'  %>
+        <% if @result.status == false %>
+          <h4 class="text-center mt-3">⌛ Results are not confirmed yet</h4>
+        <% end %>
         <strong>Your rank</strong>
         <p><%= @player.user.rank.capitalize %></p>
       <% end %>
@@ -128,16 +131,10 @@
           </div>
         <% end %>
       <% end %>
+    </div>
 
     </div>
-    </div>
     <% if @result.status == true %>
-      <% if @result.red_score > @result.blue_score %>
-        <h2 class="text-center mt-3">✅ Results confirmed, winner: red team</h2>
-      <% elsif @result.red_score < @result.blue_score%>
-        <h2 class="text-center mt-3">✅ Results confirmed, winner: blue team</h2>
-      <% else %>
-          <h2 class="text-center mt-3">Tie Game !</h2>
-      <% end %>
+      <h4 class="text-center mt-3">✅ Results are confirmed!</h4>
     <% end %>
 </div>

--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -1,7 +1,5 @@
 <div class="container">
   <h1 class="mt-3 mb-1">Results</h1>
-  <div class="game-show"
-    data-controller="game-show">
     <div class="d-flex justify-content-between align-items-center">
       <h3 class="m-0" style="font-size: 20px;">Game on <%= @game.start_date.strftime("%m/%d/%Y") %></h3>
       <% if @game.game_mode == 'competitive' %>
@@ -121,6 +119,11 @@
           <%= f.hidden_field :confirmed_results, value: true %>
           <div class="d-flex justify-content-center flex-column">
             <%= f.submit 'Confirm results', class: 'btn btn-primary mb-3' %>
+          </div>
+        <% end %>
+        <%= simple_form_for([@game, @player], url: update_player_path(@game), method: :patch) do |f| %>
+          <%= f.hidden_field :confirmed_results, value: false %>
+          <div class="d-flex justify-content-center flex-column">
             <%= f.submit 'Decline results', class: 'btn-decline' %>
           </div>
         <% end %>
@@ -137,5 +140,4 @@
           <h2 class="text-center mt-3">Tie Game !</h2>
       <% end %>
     <% end %>
-  </div>
 </div>

--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -12,8 +12,10 @@
     </div>
     <p>At <%= link_to @game.playground.name.downcase, playground_path(@game.playground.id) %></p>
     <div class="d-flex flex-column align-items-center mt-4 mb-4">
-      <strong>Your rank</strong>
-      <p><%= @player.user.rank.capitalize if @player.user.rank %></p>
+      <%  if @player.user.rank && @game.game_mode == 'competitive'  %>
+        <strong>Your rank</strong>
+        <p><%= @player.user.rank.capitalize %></p>
+      <% end %>
     </div>
 
     <div class="results d-flex justify-content-between pt-4 pb-4">
@@ -37,9 +39,8 @@
                           <%= f.hidden_field :user_id, value: player.user.id %>
                           <%= f.hidden_field :badge_id, value: badge.id %>
                           <%= f.hidden_field :result_id, value: @result.id %>
-                          <%= f.submit badge.name.capitalize, class: 'btn-decline' %>
+                          <%= f.submit badge.name.capitalize, type: :image, src: "http://res.cloudinary.com/meetball/image/upload/v1/development/#{badge.photo.key}", class: "avatar avatar-results player" %>
                         <% end %>
-                        <%# <%= cl_image_tag badge.photo.key, class: "avatar avatar-results player" %>
                       </li>
                     <% end %>
                   </ul>

--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -30,10 +30,20 @@
         <ul class="results-list d-flex flex-wrap">
           <% @players.where(team: 0).each do |player| %>
             <% if player.user.photo.attached? %>
-              <li class="results-list-item">
-                <%= cl_image_tag player.user.photo.key, class: "avatar avatar-results player" %>
-                <div class="badges-container">
+              <li class="results-list-item"
+                data-controller="results-red">
+                <%= cl_image_tag player.user.photo.key, class: "avatar avatar-results player",
+                data: { action: "click->results-red#toggleBadges" } %>
+                <div class="badges-container"
+                data-results-red-target="badges">
                   <ul class="badges badges-left p-3">
+                    <div class="mb-4">
+                      <h4>Give badges to </h4>
+                      <div class="d-flex align-items-center">
+                        <%= cl_image_tag player.user.photo.key, class: "avatar avatar-results player mb-0" %>
+                        <p class="m-2"><%= player.user.username %></p>
+                      </div>
+                    </div>
                   <div class="badges-grid">
                     <% Badge.all.each do |badge| %>
                       <li>
@@ -67,10 +77,20 @@
         <ul class="results-list d-flex flex-wrap">
           <% @players.where(team: 1).each do |player| %>
             <% if player.user.photo.attached? %>
-              <li class="results-list-item">
-                <%= cl_image_tag player.user.photo.key, class: "avatar avatar-results player" %>
-                <div class="badges-container">
+              <li class="results-list-item"
+                data-controller="results-blue">
+                <%= cl_image_tag player.user.photo.key, class: "avatar avatar-results player",
+                data: { action: "click->results-blue#toggleBadges" } %>
+                <div class="badges-container"
+                data-results-blue-target="badges">
                   <ul class="badges badges-right p-3">
+                  <div class="mb-4">
+                    <h4>Give badges to </h4>
+                    <div class="d-flex align-items-center">
+                      <%= cl_image_tag player.user.photo.key, class: "avatar avatar-results player mb-0" %>
+                      <p class="m-2"><%= player.user.username %></p>
+                    </div>
+                  </div>
                   <div class="badges-grid">
                     <% Badge.all.each do |badge| %>
                       <li>

--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -11,8 +11,8 @@
     <p>At <%= link_to @game.playground.name.downcase, playground_path(@game.playground.id) %></p>
     <div class="d-flex flex-column align-items-center mt-4 mb-4">
       <%  if @player.user.rank && @game.game_mode == 'competitive'  %>
-        <% if @result.status == false %>
-          <h4 class="text-center mt-3">⌛ Results are not confirmed yet</h4>
+        <% unless @result.status %>
+          <h4 class="text-center mt-3 mb-3">⌛ Results are not confirmed yet</h4>
         <% end %>
         <strong>Your rank</strong>
         <p><%= @player.user.rank.capitalize %></p>

--- a/app/views/shared/_games.html.erb
+++ b/app/views/shared/_games.html.erb
@@ -11,7 +11,7 @@
           <div class="game-card-players">
             <% game.players.each do |player| %>
               <% if player.user.photo.attached? %>
-                <%= cl_image_tag player.user.photo.key, class: "avatar avatar-small player" %>
+                <%= cl_image_tag player.user.photo.key, class: "avatar avatar-small player mb-0" %>
               <% else %>
                 <% if player.team == "red" %>
                   <img src="https://cdn-icons-png.flaticon.com/512/5357/5357686.png" class="avatar avatar-small player">


### PR DESCRIPTION
Changes:
- Added badges image to badges for each player
- Added javascript toggle of the give badges div
- Added decline result form on the result page

Screens:
<img width="213" alt="image" src="https://user-images.githubusercontent.com/49365826/187540554-710d834d-7664-4675-ab2d-df10aca5afc9.png">
<img width="205" alt="image" src="https://user-images.githubusercontent.com/49365826/187540603-f1b63430-69c9-4b0c-b5d4-adce37f07c44.png">
<img width="206" alt="image" src="https://user-images.githubusercontent.com/49365826/187540937-9c5b1a98-9dba-4ba0-829a-2139e37f6046.png">

Please review @jchau905 @julienLeMee @MikaelJG 